### PR TITLE
Update the code so it's fully compatible with Gravity PDF 4.0 RC2

### DIFF
--- a/includes/steps/class-step-approval.php
+++ b/includes/steps/class-step-approval.php
@@ -279,30 +279,42 @@ class Gravity_Flow_Step_Approval extends Gravity_Flow_Step {
 
 
 		// Support for Gravity PDF 4
-		if ( defined( 'PDF_EXTENDED_VERSION' ) && version_compare( PDF_EXTENDED_VERSION, '4.0-beta2' , '>=' ) ) {
-			$form_id = $this->get_form_id();
+		if ( defined( 'PDF_EXTENDED_VERSION' ) && version_compare( PDF_EXTENDED_VERSION, '4.0-RC2', '>=' ) ) {
+
+			$form_id    = $this->get_form_id();
 			$gpdf_feeds = GPDFAPI::get_form_pdfs( $form_id );
-			if ( is_array( $gpdf_feeds ) ) {
+
+			if ( ! is_wp_error( $gpdf_feeds ) ) {
+
+				/* Format the PDFs in the appropriate format for use in a select field */
 				$gpdf_choices = array();
 				foreach ( $gpdf_feeds as $gpdf_feed ) {
 					$gpdf_choices[] = array( 'label' => $gpdf_feed['name'], 'value' => $gpdf_feed['id'] );
 				}
+
+				/* Create a select box for the Gravity PDFs */
 				$pdf_setting = array(
-					'name' => 'assignee_notification_gpdf',
-					'label' => '',
-					'type' => 'checkbox_and_select',
+					'name'     => 'assignee_notification_gpdf',
+					'label'    => '',
+					'type'     => 'checkbox_and_select',
 					'checkbox' => array(
 						'label' => esc_html__( 'Attach PDF', 'gravityflow' ),
 					),
-					'select' => array(
+					'select'   => array(
 						'choices' => $gpdf_choices,
 					),
 				);
-				$assignee_notification_fields[] = $pdf_setting;
-				$pdf_setting['name'] = 'rejection_notification_gpdf';
+
+				/* Include PDF select box in assignee notification settings */
+				$assignee_notification_fields[]  = $pdf_setting;
+
+				/* Include PDF select box in rejection notification settings */
+				$pdf_setting['name']             = 'rejection_notification_gpdf';
 				$rejection_notification_fields[] = $pdf_setting;
-				$pdf_setting['name'] = 'approval_notification_gpdf';
-				$approval_notification_fields[] = $pdf_setting;
+
+				/* Include PDF select box in aproval notification settings */
+				$pdf_setting['name']             = 'approval_notification_gpdf';
+				$approval_notification_fields[]  = $pdf_setting;
 			}
 		}
 
@@ -982,7 +994,7 @@ class Gravity_Flow_Step_Approval extends Gravity_Flow_Step {
 		$notification['subject'] = $this->approval_notification_subject;
 		$notification['message'] = $this->approval_notification_message;
 
-		if ( defined( 'PDF_EXTENDED_VERSION' ) && version_compare( PDF_EXTENDED_VERSION, '4.0-beta2' , '>=' ) ) {
+		if ( defined( 'PDF_EXTENDED_VERSION' ) && version_compare( PDF_EXTENDED_VERSION, '4.0-RC2' , '>=' ) ) {
 			if ( $this->approval_notification_gpdfEnable ) {
 				$gpdf_id = $this->approval_notification_gpdfValue;
 				$notification = $this->gpdf_add_notification_attachment( $notification, $gpdf_id );
@@ -1036,7 +1048,7 @@ class Gravity_Flow_Step_Approval extends Gravity_Flow_Step {
 		$notification['subject'] = $this->rejection_notification_subject;
 		$notification['message'] = $this->rejection_notification_message;
 
-		if ( defined( 'PDF_EXTENDED_VERSION' ) && version_compare( PDF_EXTENDED_VERSION, '4.0-beta2' , '>=' ) ) {
+		if ( defined( 'PDF_EXTENDED_VERSION' ) && version_compare( PDF_EXTENDED_VERSION, '4.0-RC2', '>=' ) ) {
 			if ( $this->rejection_notification_gpdfEnable ) {
 				$gpdf_id = $this->rejection_notification_gpdfValue;
 				$notification = $this->gpdf_add_notification_attachment( $notification, $gpdf_id );

--- a/includes/steps/class-step-notification.php
+++ b/includes/steps/class-step-notification.php
@@ -133,7 +133,8 @@ class Gravity_Flow_Step_Notification extends Gravity_Flow_Step {
 	function process() {
 		$this->log_debug( __METHOD__ . '(): starting' );
 
-		if ( class_exists( 'GFPDF_Core' ) ) {
+		/* Ensure compatibility with Gravity PDF 3.x */
+		if ( defined( 'PDF_EXTENDED_VERSION' ) && version_compare( PDF_EXTENDED_VERSION, '4.0-beta1', '<' ) && class_exists( 'GFPDF_Core' ) ) {
 			global $gfpdf;
 			if ( empty( $gfpdf ) ) {
 				$gfpdf = new GFPDF_Core();


### PR DESCRIPTION
Notable changes include:

- Greatly simplifying the PDF generation command
- Tweak the checks used when using the GPDFAPI (is_wp_error is preferred)
- Updated version check to ensure commands aren't run on a version of Gravity PDF that doesn't support them
- Ensured v3 compatibility isn't run when using v4.

Note: Gravity PDF 4.0 RC2 has not yet been released to our testers. It's currently in development. 